### PR TITLE
WIP: Example of extension mechanism and usage

### DIFF
--- a/src/gtimelog/__init__.py
+++ b/src/gtimelog/__init__.py
@@ -1,3 +1,31 @@
 # The gtimelog package.
 
 __version__ = '0.9.2.dev0'
+
+# A simplistic hook mechanism. Extensions should do this:
+#   import gtimelog
+#   gtimelog.hooks['ui'].append(extend_ui)
+# The code that provides the hook then calls each function in the list for
+# the 'ui' hook.
+#
+# The function signature for each hook's callback is different. See below.
+hooks = {
+    # Callback: foo(mw, builder, resource_dir), where mw is the MainWindow
+    # instance, buider is the GtkBuilder object used to load UI files, and
+    # resource_dir is where ther UI files should be stored. Callback will
+    # be called before signals are connected.
+    'ui': [],
+
+    # Callback: foo(). Called before the GTK main loop starts.
+    'before-gtk-main': [],
+
+    # Callback: foo(). Called after the GTK main loop ends.
+    'after-gtk-main': [],
+}
+
+def call_hook(name, *args, **kwargs):
+    '''Call every hook callback (or until first one that returns non-None).'''
+    for func in hooks[name]:
+        ret = func(*args, **kwargs)
+        if ret is not None:
+            return ret

--- a/src/gtimelog/collabora_ext.py
+++ b/src/gtimelog/collabora_ext.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+import gtimelog
+
+
+class CollaboraExtension(object):
+
+    def init(self):
+        gtimelog.hooks['before-gtk-main'].append(self.before_gtk_main)
+        gtimelog.hooks['ui'].append(self.ui)
+
+    def before_gtk_main(self):
+        print('Testing hook')
+
+    def ui(self, main_window, builder, resource_dir):
+        print('Hook called')
+        menu_item = Gtk.MenuItem(label='Testing')
+        print(menu_item)
+        menu_item.show()
+
+        menu_item.connect('activate', lambda widget: print('menu modified'))
+
+        report_menu = builder.get_object('menuitem2_menu')
+        report_menu.prepend(menu_item)
+        print('prepended')
+
+ce = CollaboraExtension()
+def init():
+    print('Collabora gtimelog extension module init')
+    ce.init()


### PR DESCRIPTION
Adds the extension mechanism created ages ago by Lars Wirzenius at http://cgit.collabora.com/git/gtimelog.git/?h=sync-with-upstream

Is this something you'd be happy to take upstream? The idea would be, as was done to a large extent in that branch and bitrotted, to move all the Collabora changes into a collabora_ext file that we carry separately and otherwise sync more closely with upstream.

I don't know if you'd want to supply all the hooks listed in http://cgit.collabora.com/git/gtimelog.git/tree/src/gtimelog/__init__.py?h=sync-with-upstream from the beginning or add them as extensions had a need for them. I imagine some of them no longer make sense.
