### PR TITLE
(Preliminary) pull req - settings instead virtual_midnight and data_file

### DIFF
--- a/scripts/export-my-calendar.py
+++ b/scripts/export-my-calendar.py
@@ -17,7 +17,6 @@ datadir = settings.get_data_dir()
 settings_file = settings.get_config_file()
 if os.path.exists(settings_file):
     settings.load(settings_file)
-timelog = gtimelog.TimeLog(settings.get_timelog_file(),
-                           settings.virtual_midnight)
+timelog = gtimelog.TimeLog(settings, settings.get_timelog_file())
 window = timelog.window_for(d1, d2)
 window.icalendar(open(outputfile, 'w'))

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1005,8 +1005,9 @@ class Application(Gtk.Application):
 
         if self.opts.sample_config:
             settings = Settings()
-            settings.save("gtimelogrc.sample")
-            print("Sample configuration file written to gtimelogrc.sample")
+            sample_cfgfile = settings.get_config_file() + ".sample" 
+            settings.save(sample_cfgfile)
+            print("Sample configuration file written to %s" % sample_cfgfile)
             print("Edit it and save as %s" % settings.get_config_file())
             return
 
@@ -1044,9 +1045,8 @@ class Application(Gtk.Application):
             settings.load(settings_file)
         if self.opts.debug:
             print('Assuming date changes at %s' % settings.virtual_midnight)
-            print('Loading time log from %s' % settings.get_timelog_file())
-        timelog = TimeLog(settings.get_timelog_file(),
-                          settings.virtual_midnight)
+            print('Loading time log from %s' % settings.data_file)
+        timelog = TimeLog(settings)
         if settings.task_list_url:
             if self.opts.debug:
                 print('Loading cached remote tasks from %s' %

--- a/src/gtimelog/tests.py
+++ b/src/gtimelog/tests.py
@@ -251,13 +251,18 @@ def doctest_uniq():
 def doctest_TimeWindow_reread_no_file():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... data_file = /nosuchfile
+        ... '''))
         >>> min = datetime(2013, 12, 3)
         >>> max = datetime(2013, 12, 4)
-        >>> vm = time(2, 0)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow('/nosuchfile', min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
 
     There's no error.
 
@@ -271,19 +276,22 @@ def doctest_TimeWindow_reread_no_file():
 def doctest_TimeWindow_reread_bad_timestamp():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
-        >>> min = datetime(2013, 12, 4)
-        >>> max = datetime(2013, 12, 5)
-        >>> vm = time(2, 0)
-
-        >>> sampledata = StringIO('''
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO('''
         ... 2013-12-04 09:00: start **
         ... # hey: this is not a timestamp
         ... 2013-12-04 09:14: gtimelog: write some tests
         ... ''')
+        >>> min = datetime(2013, 12, 4)
+        >>> max = datetime(2013, 12, 5)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
 
     There's no error, the line with a bad timestamp is silently skipped.
 
@@ -296,20 +304,23 @@ def doctest_TimeWindow_reread_bad_timestamp():
 def doctest_TimeWindow_reread_bad_ordering():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
-        >>> min = datetime(2013, 12, 4)
-        >>> max = datetime(2013, 12, 5)
-        >>> vm = time(2, 0)
-
-        >>> sampledata = StringIO('''
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO('''
         ... 2013-12-04 09:00: start **
         ... 2013-12-04 09:14: gtimelog: write some tests
         ... 2013-12-04 09:10: gtimelog: whoops clock got all confused
         ... 2013-12-04 09:10: gtimelog: so this will need to be fixed
         ... ''')
+        >>> min = datetime(2013, 12, 4)
+        >>> max = datetime(2013, 12, 5)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
 
     There's no error, the timestamps have been reordered, but note that
     order was preserved for events with the same timestamp
@@ -330,22 +341,26 @@ def doctest_TimeWindow_reread_bad_ordering():
 def doctest_TimeWindow_reread_callbacks():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
-        >>> min = datetime(2013, 12, 4)
-        >>> max = datetime(2013, 12, 5)
-        >>> vm = time(2, 0)
-
-        >>> sampledata = StringIO('''
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO('''
         ... 2013-12-03 09:00: stuff **
         ... 2013-12-04 09:00: start **
         ... 2013-12-04 09:14: gtimelog: write some tests
         ... 2013-12-06 09:00: future **
         ... ''')
+        >>> min = datetime(2013, 12, 4)
+        >>> max = datetime(2013, 12, 5)
 
         >>> l = []
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm, callback=l.append)
+        >>> window = TimeWindow(settings, min, max, 
+        ...        callback=l.append)
 
     The callback is invoked with all the entries (not just those in the
     selected time window).  We use it to populate history completion.
@@ -359,12 +374,13 @@ def doctest_TimeWindow_reread_callbacks():
 def doctest_TimeWindow_count_days():
     """Test for TimeWindow.count_days
 
-        >>> from datetime import datetime, time
-        >>> min = datetime(2013, 12, 2)
-        >>> max = datetime(2013, 12, 9)
-        >>> vm = time(2, 0)
-
-        >>> sampledata = StringIO('''
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO('''
         ... 2013-12-04 09:00: start **
         ... 2013-12-04 09:14: gtimelog: write some tests
         ... 2013-12-04 09:10: gtimelog: whoops clock got all confused
@@ -376,9 +392,11 @@ def doctest_TimeWindow_count_days():
         ... 2013-12-08 09:00: work **
         ... 2013-12-08 09:01: and stuff
         ... ''')
+        >>> min = datetime(2013, 12, 2)
+        >>> max = datetime(2013, 12, 9)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> window.count_days()
         3
 
@@ -388,11 +406,16 @@ def doctest_TimeWindow_count_days():
 def doctest_TimeWindow_last_entry():
     """Test for TimeWindow.last_entry
 
-        >>> from datetime import datetime, time
-        >>> vm = time(2, 0)
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(StringIO(), None, None, vm)
+        >>> window = TimeWindow(settings, None, None)
 
     Case #1: no items
 
@@ -449,12 +472,13 @@ def doctest_TimeWindow_last_entry():
 def doctest_TimeWindow_to_csv_complete():
     r"""Tests for TimeWindow.to_csv_complete
 
-        >>> from datetime import datetime, time
-        >>> min = datetime(2008, 6, 1)
-        >>> max = datetime(2008, 7, 1)
-        >>> vm = time(2, 0)
-
-        >>> sampledata = StringIO('''
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO('''
         ... 2008-06-03 12:45: start
         ... 2008-06-03 13:00: something
         ... 2008-06-03 14:45: something else
@@ -464,9 +488,11 @@ def doctest_TimeWindow_to_csv_complete():
         ... 2008-06-05 14:15: rest **
         ... 2008-06-05 16:15: let's not mention this ever again ***
         ... ''')
+        >>> min = datetime(2008, 6, 1)
+        >>> max = datetime(2008, 7, 1)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
 
         >>> import sys
         >>> window.to_csv_complete(sys.stdout)
@@ -481,12 +507,13 @@ def doctest_TimeWindow_to_csv_complete():
 def doctest_TimeWindow_to_csv_daily():
     r"""Tests for TimeWindow.to_csv_daily
 
-        >>> from datetime import datetime, time
-        >>> min = datetime(2008, 6, 1)
-        >>> max = datetime(2008, 7, 1)
-        >>> vm = time(2, 0)
-
-        >>> sampledata = StringIO('''
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO('''
         ... 2008-06-03 12:45: start
         ... 2008-06-03 13:00: something
         ... 2008-06-03 14:45: something else
@@ -495,9 +522,11 @@ def doctest_TimeWindow_to_csv_daily():
         ... 2008-06-05 13:15: something
         ... 2008-06-05 14:15: rest **
         ... ''')
+        >>> min = datetime(2008, 6, 1)
+        >>> max = datetime(2008, 7, 1)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
 
         >>> import sys
         >>> window.to_csv_daily(sys.stdout)
@@ -514,14 +543,19 @@ def doctest_Reports_weekly_report_categorized():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -530,7 +564,7 @@ def doctest_Reports_weekly_report_categorized():
         <BLANKLINE>
         No work done this week.
 
-        >>> fh = StringIO('\n'.join([
+        >>> settings.data_file = StringIO('\n'.join([
         ...    '2010-01-30 09:00: start',
         ...    '2010-01-30 09:23: Bing: stuff',
         ...    '2010-01-30 12:54: Bong: other stuff',
@@ -538,7 +572,7 @@ def doctest_Reports_weekly_report_categorized():
         ...    '2010-01-30 23:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -579,14 +613,19 @@ def doctest_Reports_monthly_report_categorized():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -595,7 +634,7 @@ def doctest_Reports_monthly_report_categorized():
         <BLANKLINE>
         No work done this month.
 
-        >>> fh = StringIO('\n'.join([
+        >>> settings.data_file = StringIO('\n'.join([
         ...    '2010-01-30 09:00: start',
         ...    '2010-01-30 09:23: Bing: stuff',
         ...    '2010-01-30 12:54: Bong: other stuff',
@@ -603,7 +642,7 @@ def doctest_Reports_monthly_report_categorized():
         ...    '2010-01-30 23:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -641,10 +680,15 @@ def doctest_Reports_report_categories():
 
         >>> import sys
 
-        >>> from datetime import datetime, time, timedelta
+        >>> from datetime import datetime, timedelta
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
@@ -652,7 +696,7 @@ def doctest_Reports_report_categories():
         ...    'Bing': timedelta(2),
         ...    None: timedelta(1)}
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports._report_categories(sys.stdout, categories)
         <BLANKLINE>
@@ -670,14 +714,19 @@ def doctest_Reports_daily_report():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 30)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.daily_report(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -685,7 +734,7 @@ def doctest_Reports_daily_report():
         <BLANKLINE>
         No work done today.
 
-        >>> fh = StringIO('\n'.join([
+        >>> settings.data_file = StringIO('\n'.join([
         ...    '2010-01-30 09:00: start',
         ...    '2010-01-30 09:23: Bing: stuff',
         ...    '2010-01-30 12:54: Bong: other stuff',
@@ -693,7 +742,7 @@ def doctest_Reports_daily_report():
         ...    '2010-01-30 15:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.daily_report(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -727,14 +776,19 @@ def doctest_Reports_weekly_report_plain():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -742,7 +796,7 @@ def doctest_Reports_weekly_report_plain():
         <BLANKLINE>
         No work done this week.
 
-        >>> fh = StringIO('\n'.join([
+        >>> settings.data_file = StringIO('\n'.join([
         ...    '2010-01-30 09:00: start',
         ...    '2010-01-30 09:23: Bing: stuff',
         ...    '2010-01-30 12:54: Bong: other stuff',
@@ -750,7 +804,7 @@ def doctest_Reports_weekly_report_plain():
         ...    '2010-01-30 15:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -778,14 +832,19 @@ def doctest_Reports_monthly_report_plain():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2007, 9, 1)
         >>> max = datetime(2007, 10, 1)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -793,7 +852,7 @@ def doctest_Reports_monthly_report_plain():
         <BLANKLINE>
         No work done this month.
 
-        >>> fh = StringIO('\n'.join([
+        >>> settings.data_file = StringIO('\n'.join([
         ...    '2007-09-30 09:00: start',
         ...    '2007-09-30 09:23: Bing: stuff',
         ...    '2007-09-30 12:54: Bong: other stuff',
@@ -801,7 +860,7 @@ def doctest_Reports_monthly_report_plain():
         ...    '2007-09-30 15:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -829,14 +888,19 @@ def doctest_Reports_custom_range_report_categorized():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
+        >>> settings.data_file = StringIO()
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 2, 1)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.custom_range_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                         'Bob Jones')
@@ -845,7 +909,7 @@ def doctest_Reports_custom_range_report_categorized():
         <BLANKLINE>
         No work done this custom range.
 
-        >>> fh = StringIO('\n'.join([
+        >>> settings.data_file = StringIO('\n'.join([
         ...    '2010-01-20 09:00: arrived',
         ...    '2010-01-20 09:30: asdf',
         ...    '2010-01-20 10:00: Bar: Foo',
@@ -857,7 +921,7 @@ def doctest_Reports_custom_range_report_categorized():
         ...    '2010-01-30 23:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, min, max)
         >>> reports = Reports(window)
         >>> reports.custom_range_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                         'Bob Jones')
@@ -1032,11 +1096,6 @@ class TestSettings(unittest.TestCase):
         self.settings.get_config_dir = lambda: os.path.normpath('~/.config/gtimelog')
         self.assertEqual(self.settings.get_config_file(),
                          os.path.normpath('~/.config/gtimelog/gtimelogrc'))
-
-    def test_get_timelog_file(self):
-        self.settings.get_data_dir = lambda: os.path.normpath('~/.local/share/gtimelog')
-        self.assertEqual(self.settings.get_timelog_file(),
-                         os.path.normpath('~/.local/share/gtimelog/timelog.txt'))
 
     def test_load(self):
         self.settings.load('/dev/null')


### PR DESCRIPTION
Hallo Marius.

I'm sending 2 preliminary pull requests. So you can see what I'm working on.

In this pull request I'm using settings instead virtual_midnight and data_file. Settings are availeble in TimeLog and TimeWindow classes. Inside the classes values are retrieved directly from settings.

Data_file is alse added as settings parameter. Resolved in constructor of settings or when settings are loaded from file.

What do you think about it. If there are many errors like PEP8/formatting, ignore them for now. Is this idea better than in later pull request?
