### PR TITLE
(Preliminary) pull req - settings instead virtual_midnight

### DIFF
--- a/scripts/export-my-calendar.py
+++ b/scripts/export-my-calendar.py
@@ -17,7 +17,6 @@ datadir = settings.get_data_dir()
 settings_file = settings.get_config_file()
 if os.path.exists(settings_file):
     settings.load(settings_file)
-timelog = gtimelog.TimeLog(settings.get_timelog_file(),
-                           settings.virtual_midnight)
+timelog = gtimelog.TimeLog(settings, settings.get_timelog_file())
 window = timelog.window_for(d1, d2)
 window.icalendar(open(outputfile, 'w'))

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1045,8 +1045,7 @@ class Application(Gtk.Application):
         if self.opts.debug:
             print('Assuming date changes at %s' % settings.virtual_midnight)
             print('Loading time log from %s' % settings.get_timelog_file())
-        timelog = TimeLog(settings.get_timelog_file(),
-                          settings.virtual_midnight)
+        timelog = TimeLog(settings, settings.get_timelog_file())
         if settings.task_list_url:
             if self.opts.debug:
                 print('Loading cached remote tasks from %s' %

--- a/src/gtimelog/settings.py
+++ b/src/gtimelog/settings.py
@@ -54,6 +54,14 @@ class Settings(object):
 
     report_style = 'plain'
 
+    def __init__(self, file=None):
+        """init method with optional parameters
+        
+        file ... can be filename or file object
+        """
+        if file:
+            self.load(file)
+
     def check_legacy_config(self):
         envar_home = os.environ.get('GTIMELOG_HOME')
         if envar_home is not None:
@@ -120,9 +128,19 @@ class Settings(object):
         def _unicode(self, value):
             return value.decode(self._encoding)
 
-    def load(self, filename):
+    def load(self, file):
+        """load config file
+        
+        file ... can be filename or file object
+        """
         config = self._config()
-        config.read([filename])
+        if hasattr(file, "read"):
+            # we have file object
+            config.readfp(file)
+        else:
+            # we have filename
+            config.read([file])
+            
         self.email = config.get('gtimelog', 'list-email')
         self.name = self._unicode(config.get('gtimelog', 'name'))
         self.editor = config.get('gtimelog', 'editor')

--- a/src/gtimelog/tests.py
+++ b/src/gtimelog/tests.py
@@ -251,13 +251,17 @@ def doctest_uniq():
 def doctest_TimeWindow_reread_no_file():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2013, 12, 3)
         >>> max = datetime(2013, 12, 4)
-        >>> vm = time(2, 0)
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow('/nosuchfile', min, max, vm)
+        >>> window = TimeWindow(settings, '/nosuchfile', min, max)
 
     There's no error.
 
@@ -271,10 +275,14 @@ def doctest_TimeWindow_reread_no_file():
 def doctest_TimeWindow_reread_bad_timestamp():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2013, 12, 4)
         >>> max = datetime(2013, 12, 5)
-        >>> vm = time(2, 0)
 
         >>> sampledata = StringIO('''
         ... 2013-12-04 09:00: start **
@@ -283,7 +291,7 @@ def doctest_TimeWindow_reread_bad_timestamp():
         ... ''')
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, sampledata, min, max)
 
     There's no error, the line with a bad timestamp is silently skipped.
 
@@ -296,10 +304,14 @@ def doctest_TimeWindow_reread_bad_timestamp():
 def doctest_TimeWindow_reread_bad_ordering():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2013, 12, 4)
         >>> max = datetime(2013, 12, 5)
-        >>> vm = time(2, 0)
 
         >>> sampledata = StringIO('''
         ... 2013-12-04 09:00: start **
@@ -309,7 +321,7 @@ def doctest_TimeWindow_reread_bad_ordering():
         ... ''')
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, sampledata, min, max)
 
     There's no error, the timestamps have been reordered, but note that
     order was preserved for events with the same timestamp
@@ -330,10 +342,14 @@ def doctest_TimeWindow_reread_bad_ordering():
 def doctest_TimeWindow_reread_callbacks():
     """Test for TimeWindow.reread
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2013, 12, 4)
         >>> max = datetime(2013, 12, 5)
-        >>> vm = time(2, 0)
 
         >>> sampledata = StringIO('''
         ... 2013-12-03 09:00: stuff **
@@ -345,7 +361,8 @@ def doctest_TimeWindow_reread_callbacks():
         >>> l = []
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm, callback=l.append)
+        >>> window = TimeWindow(settings, sampledata, min, max, 
+        ...        callback=l.append)
 
     The callback is invoked with all the entries (not just those in the
     selected time window).  We use it to populate history completion.
@@ -359,10 +376,14 @@ def doctest_TimeWindow_reread_callbacks():
 def doctest_TimeWindow_count_days():
     """Test for TimeWindow.count_days
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2013, 12, 2)
         >>> max = datetime(2013, 12, 9)
-        >>> vm = time(2, 0)
 
         >>> sampledata = StringIO('''
         ... 2013-12-04 09:00: start **
@@ -378,7 +399,7 @@ def doctest_TimeWindow_count_days():
         ... ''')
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, sampledata, min, max)
         >>> window.count_days()
         3
 
@@ -388,11 +409,15 @@ def doctest_TimeWindow_count_days():
 def doctest_TimeWindow_last_entry():
     """Test for TimeWindow.last_entry
 
-        >>> from datetime import datetime, time
-        >>> vm = time(2, 0)
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(StringIO(), None, None, vm)
+        >>> window = TimeWindow(settings, StringIO(), None, None)
 
     Case #1: no items
 
@@ -449,10 +474,14 @@ def doctest_TimeWindow_last_entry():
 def doctest_TimeWindow_to_csv_complete():
     r"""Tests for TimeWindow.to_csv_complete
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2008, 6, 1)
         >>> max = datetime(2008, 7, 1)
-        >>> vm = time(2, 0)
 
         >>> sampledata = StringIO('''
         ... 2008-06-03 12:45: start
@@ -466,7 +495,7 @@ def doctest_TimeWindow_to_csv_complete():
         ... ''')
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, sampledata, min, max)
 
         >>> import sys
         >>> window.to_csv_complete(sys.stdout)
@@ -481,10 +510,14 @@ def doctest_TimeWindow_to_csv_complete():
 def doctest_TimeWindow_to_csv_daily():
     r"""Tests for TimeWindow.to_csv_daily
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
         >>> min = datetime(2008, 6, 1)
         >>> max = datetime(2008, 7, 1)
-        >>> vm = time(2, 0)
 
         >>> sampledata = StringIO('''
         ... 2008-06-03 12:45: start
@@ -497,7 +530,7 @@ def doctest_TimeWindow_to_csv_daily():
         ... ''')
 
         >>> from gtimelog.timelog import TimeWindow
-        >>> window = TimeWindow(sampledata, min, max, vm)
+        >>> window = TimeWindow(settings, sampledata, min, max)
 
         >>> import sys
         >>> window.to_csv_daily(sys.stdout)
@@ -514,14 +547,18 @@ def doctest_Reports_weekly_report_categorized():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -538,7 +575,7 @@ def doctest_Reports_weekly_report_categorized():
         ...    '2010-01-30 23:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, fh, min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -579,14 +616,18 @@ def doctest_Reports_monthly_report_categorized():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -603,7 +644,7 @@ def doctest_Reports_monthly_report_categorized():
         ...    '2010-01-30 23:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, fh, min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                   'Bob Jones')
@@ -641,10 +682,14 @@ def doctest_Reports_report_categories():
 
         >>> import sys
 
-        >>> from datetime import datetime, time, timedelta
+        >>> from datetime import datetime, timedelta
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
@@ -652,7 +697,7 @@ def doctest_Reports_report_categories():
         ...    'Bing': timedelta(2),
         ...    None: timedelta(1)}
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports._report_categories(sys.stdout, categories)
         <BLANKLINE>
@@ -670,14 +715,18 @@ def doctest_Reports_daily_report():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 30)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports.daily_report(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -693,7 +742,7 @@ def doctest_Reports_daily_report():
         ...    '2010-01-30 15:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, fh, min, max)
         >>> reports = Reports(window)
         >>> reports.daily_report(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -727,14 +776,18 @@ def doctest_Reports_weekly_report_plain():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 1, 31)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -750,7 +803,7 @@ def doctest_Reports_weekly_report_plain():
         ...    '2010-01-30 15:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, fh, min, max)
         >>> reports = Reports(window)
         >>> reports.weekly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -778,14 +831,18 @@ def doctest_Reports_monthly_report_plain():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2007, 9, 1)
         >>> max = datetime(2007, 10, 1)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -801,7 +858,7 @@ def doctest_Reports_monthly_report_plain():
         ...    '2007-09-30 15:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, fh, min, max)
         >>> reports = Reports(window)
         >>> reports.monthly_report_plain(sys.stdout, 'foo@bar.com', 'Bob Jones')
         To: foo@bar.com
@@ -829,14 +886,18 @@ def doctest_Reports_custom_range_report_categorized():
 
         >>> import sys
 
-        >>> from datetime import datetime, time
+        >>> from datetime import datetime
         >>> from gtimelog.timelog import TimeWindow, Reports
+        >>> from gtimelog.settings import Settings
+        >>> settings = Settings(StringIO('''
+        ... [gtimelog]
+        ... virtual_midnight = 02:00
+        ... '''))
 
-        >>> vm = time(2, 0)
         >>> min = datetime(2010, 1, 25)
         >>> max = datetime(2010, 2, 1)
 
-        >>> window = TimeWindow(StringIO(), min, max, vm)
+        >>> window = TimeWindow(settings, StringIO(), min, max)
         >>> reports = Reports(window)
         >>> reports.custom_range_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                         'Bob Jones')
@@ -857,7 +918,7 @@ def doctest_Reports_custom_range_report_categorized():
         ...    '2010-01-30 23:46: misc',
         ...    '']))
 
-        >>> window = TimeWindow(fh, min, max, vm)
+        >>> window = TimeWindow(settings, fh, min, max)
         >>> reports = Reports(window)
         >>> reports.custom_range_report_categorized(sys.stdout, 'foo@bar.com',
         ...                                         'Bob Jones')

--- a/src/gtimelog/timelog.py
+++ b/src/gtimelog/timelog.py
@@ -130,12 +130,13 @@ class TimeWindow(object):
     oldest) timestamp in the file.
     """
 
-    def __init__(self, filename, min_timestamp, max_timestamp,
-                 virtual_midnight, callback=None):
+    def __init__(self, settings, filename, min_timestamp, max_timestamp,
+                 callback=None):
         self.filename = filename
         self.min_timestamp = min_timestamp
         self.max_timestamp = max_timestamp
-        self.virtual_midnight = virtual_midnight
+        self.settings = settings
+        self.virtual_midnight = settings.virtual_midnight
         self.reread(callback)
 
     def reread(self, callback=None):
@@ -697,9 +698,10 @@ class TimeLog(object):
     the end.
     """
 
-    def __init__(self, filename, virtual_midnight):
+    def __init__(self, settings, filename):
+        self.settings = settings
         self.filename = filename
-        self.virtual_midnight = virtual_midnight
+        self.virtual_midnight = settings.virtual_midnight
         self.reread()
 
     def virtual_today(self):
@@ -735,8 +737,7 @@ class TimeLog(object):
         min = datetime.datetime.combine(self.day, self.virtual_midnight)
         max = min + datetime.timedelta(1)
         self.history = []
-        self.window = TimeWindow(self.filename, min, max,
-                                 self.virtual_midnight,
+        self.window = TimeWindow(self.settings, self.filename, min, max,
                                  callback=self.history.append)
         self.need_space = not self.window.items
         self._cache = {(min, max): self.window}
@@ -746,7 +747,7 @@ class TimeLog(object):
         try:
             return self._cache[min, max]
         except KeyError:
-            window = TimeWindow(self.filename, min, max, self.virtual_midnight)
+            window = TimeWindow(self.settings, self.filename, min, max)
             if len(self._cache) > 1000:
                 self._cache.clear()
             self._cache[min, max] = window


### PR DESCRIPTION
Hallo Marius.

I'm sending 2 preliminary pull requests. So you can see what I'm working on.

In this pull request I'm using settings instead of virtual_midnight. So full settings are available in TimeLog and TimeWindow classes. Other parameters are not altered.

What do you think about it. If there is still many errors like PEP8/formatting, ignore them for now. Is the idea better than in earlier pull request?
