### PR TITLE
Fix UnicodeWarning when searching for completion choices

### DIFF
--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -479,7 +479,7 @@ class MainWindow:
         self.history_pos = 0
         if not self.have_completion:
             return
-        if entry not in [row[0] for row in self.completion_choices]:
+        if entry not in [row[0].decode('UTF-8') for row in self.completion_choices]:
             self.completion_choices.append([entry])
 
     def jump_to_date(self, date):


### PR DESCRIPTION
Typing non-ascii characters (German Umlauts, in my example) into
the `task_entry` text box throws me a UnicodeWarning:

```
./src/gtimelog/main.py:482: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  if entry not in [row[0] for row in self.completion_choices]:
```

Related bugs in PyGTK:
- https://bugzilla.gnome.org/show_bug.cgi?id=323901
- https://bugzilla.gnome.org/show_bug.cgi?id=314560
