### PR TITLE
Add AppData file

### DIFF
--- a/gtimelog.appdata.xml
+++ b/gtimelog.appdata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+    <id type="desktop">gtimelog.desktop</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-2.0</project_license>
+
+    <name>GTimeLog</name>
+    <summary>Unobtrusively keep track of your time</summary>
+    <description>
+        <p>GTimeLog is a small GTK+ app for keeping track of your time. Its main goal is to be as unobtrusive as possible.</p>
+    </description>
+    <screenshots>
+        <screenshot width="802" height="533" type="default">https://mg.pov.lt/gtimelog/gtimelog-gtk3.png</screenshot>
+    </screenshots>
+    <url type="homepage">https://mg.pov.lt/gtimelog/</url>
+    <updatecontact>marius@gedmin.as</updatecontact>
+</application>


### PR DESCRIPTION
AppData files are suggested when packaging desktop applications for Fedora, so here is a (very basic) one. It would be great to have translations and an extended description, but at least it's a start.