### PR TITLE
Use unittest.mock in Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import os
 import re
 import io
+import sys
 from setuptools import setup
 
 here = os.path.dirname(__file__)
@@ -40,6 +41,11 @@ long_description = (
     older_changes
 )
 
+tests_require = ['freezegun']
+if sys.version_info < (3,):
+    # Python 2 doesn't have unittest.mock
+    tests_require.append('mock')
+
 setup(
     name='gtimelog',
     version=version,
@@ -64,7 +70,7 @@ setup(
     package_dir={'': 'src'},
     package_data={'gtimelog': ['*.ui', '*.png']},
     test_suite='gtimelog.tests',
-    tests_require=['freezegun', 'mock'],
+    tests_require=tests_require,
     zip_safe=False,
     entry_points="""
     [gui_scripts]

--- a/src/gtimelog/tests/test_main.py
+++ b/src/gtimelog/tests/test_main.py
@@ -4,7 +4,12 @@
 import textwrap
 import unittest
 
-import mock
+try:
+    # Python 3
+    from unittest import mock
+except ImportError:
+    # Python 2
+    import mock
 
 
 gi = mock.MagicMock()

--- a/src/gtimelog/tests/test_timelog.py
+++ b/src/gtimelog/tests/test_timelog.py
@@ -16,7 +16,12 @@ except ImportError:
     from io import StringIO
 
 import freezegun
-import mock
+try:
+    # Python 3
+    from unittest import mock
+except ImportError:
+    # Python 2
+    import mock
 
 from gtimelog.timelog import TimeLog, Reports, Exports, TaskList
 


### PR DESCRIPTION
There's no need to pull in an extra dependency for Python 3.   We run gtimelog in Python 3 on Debian.