### PR TITLE
Add a search/filter bar

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,9 @@ Changelog
 
 * History browsing can show you weeks/months, not just days.
 
+* You can filter the displayed tasks, with a total shown at the bottom
+  (GH: #88).
+
 * There's now a preferences dialog (GH: #47).
 
 * Window size and task pane size/visibility are remembered across

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtimelog 0.10.dev0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-01 12:18+0300\n"
+"POT-Creation-Date: 2016-04-06 17:07+0300\n"
 "PO-Revision-Date: 2015-09-04 10:53+0300\n"
 "Last-Translator: Marius Gedminas <marius@gedmin.as>\n"
 "Language-Team: <marius@gedmin.as>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../gtimelog.desktop.in.h:1 ../src/gtimelog/main.py:178
-#: ../src/gtimelog/main.py:1095 ../src/gtimelog/about.ui.h:1
+#: ../src/gtimelog/main.py:1096 ../src/gtimelog/about.ui.h:1
 #: ../src/gtimelog/gtimelog.ui.h:10
 msgid "Time Log"
 msgstr ""
@@ -145,114 +145,119 @@ msgstr ""
 msgid "Couldn't append to {}: {}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1162
+#: ../src/gtimelog/main.py:1163
 msgid "%H:%M"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1410
+#: ../src/gtimelog/main.py:1411
 msgid "{0:%A, %Y-%m-%d}\n"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1435
+#: ../src/gtimelog/main.py:1444
+#, python-brace-format
+msgid "Total for {0}: {1} ({2} per day)"
+msgstr ""
+
+#: ../src/gtimelog/main.py:1446
 #, python-brace-format
 msgid "Total for {0}: {1}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1470
+#: ../src/gtimelog/main.py:1479
 msgid "({0:%H:%M}-{1:%H:%M})"
 msgstr "({0:%H:%M}–{1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1536
+#: ../src/gtimelog/main.py:1545
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1537
+#: ../src/gtimelog/main.py:1546
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1539
+#: ../src/gtimelog/main.py:1548
 #, python-brace-format
 msgid "Total work done this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1540
+#: ../src/gtimelog/main.py:1549
 #, python-brace-format
 msgid "Total work done this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1542
+#: ../src/gtimelog/main.py:1551
 #, python-brace-format
 msgid "Total work done this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1543
+#: ../src/gtimelog/main.py:1552
 #, python-brace-format
 msgid "Total work done this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1562
+#: ../src/gtimelog/main.py:1571
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1563
+#: ../src/gtimelog/main.py:1572
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1565
+#: ../src/gtimelog/main.py:1574
 #, python-brace-format
 msgid "Total slacking this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1566
+#: ../src/gtimelog/main.py:1575
 #, python-brace-format
 msgid "Total slacking this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1568
+#: ../src/gtimelog/main.py:1577
 #, python-brace-format
 msgid "Total slacking this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1569
+#: ../src/gtimelog/main.py:1578
 #, python-brace-format
 msgid "Total slacking this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1593
+#: ../src/gtimelog/main.py:1602
 msgid "Time left at work: {0} (should've finished at {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1596
+#: ../src/gtimelog/main.py:1605
 msgid "Time left at work: {0} (till {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1610
+#: ../src/gtimelog/main.py:1619
 #, python-brace-format
 msgid "At office today: {0} ({1} overtime)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1616
+#: ../src/gtimelog/main.py:1625
 #, python-brace-format
 msgid "At office today: {0} ({1} left)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1777
+#: ../src/gtimelog/main.py:1786
 msgid "Tasks"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1792
+#: ../src/gtimelog/main.py:1801
 msgid "Other"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1814 ../src/gtimelog/menus.ui.h:1
+#: ../src/gtimelog/main.py:1823 ../src/gtimelog/menus.ui.h:1
 msgid "Preferences"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1818
+#: ../src/gtimelog/main.py:1827
 msgid "Close"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtimelog 0.10.dev0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-12 09:43+0200\n"
+"POT-Creation-Date: 2016-04-01 12:18+0300\n"
 "PO-Revision-Date: 2015-09-04 10:53+0300\n"
 "Last-Translator: Marius Gedminas <marius@gedmin.as>\n"
 "Language-Team: <marius@gedmin.as>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../gtimelog.desktop.in.h:1 ../src/gtimelog/main.py:178
-#: ../src/gtimelog/main.py:1076 ../src/gtimelog/about.ui.h:1
+#: ../src/gtimelog/main.py:1095 ../src/gtimelog/about.ui.h:1
 #: ../src/gtimelog/gtimelog.ui.h:10
 msgid "Time Log"
 msgstr ""
@@ -90,164 +90,169 @@ msgstr ""
 msgid "Settings already migrated to GSettings (org.gtimelog)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:700
+#: ../src/gtimelog/main.py:713
 #, python-brace-format
 msgid "Settings from {filename} migrated to GSettings (org.gtimelog)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:748
+#: ../src/gtimelog/main.py:761
 msgid "Report already sent"
 msgstr ""
 
-#: ../src/gtimelog/main.py:752
+#: ../src/gtimelog/main.py:765
 msgid "Report already sent (to {})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:767
+#: ../src/gtimelog/main.py:780
 msgid "Downloading tasks..."
 msgstr ""
 
-#: ../src/gtimelog/main.py:782
+#: ../src/gtimelog/main.py:795
 msgid "Download failed."
 msgstr ""
 
-#: ../src/gtimelog/main.py:929
+#: ../src/gtimelog/main.py:942
 msgid "{0:%A, %Y-%m-%d} (week {1:0>2})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:935
+#: ../src/gtimelog/main.py:948
 msgid "{0}, week {1} ({2:%B %-d}-{3:%-d})"
 msgstr "{0}, week {1} ({2:%B %-d}–{3:%-d})"
 
-#: ../src/gtimelog/main.py:938
+#: ../src/gtimelog/main.py:951
 msgid "{0:%B %Y}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1006
+#: ../src/gtimelog/main.py:1022
 msgid "Report"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1029
+#: ../src/gtimelog/main.py:1045
 msgid "Couldn't send email to {}."
 msgstr ""
 
-#: ../src/gtimelog/main.py:1050
+#: ../src/gtimelog/main.py:1066
 #, python-format
 msgid "Couldn't execute %s: %s"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1054
+#: ../src/gtimelog/main.py:1070
 #, python-format
 msgid "Couldn't send email: %s returned code %d"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1064
+#: ../src/gtimelog/main.py:1080
 msgid "Couldn't append to {}: {}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1143
+#: ../src/gtimelog/main.py:1162
 msgid "%H:%M"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1384
+#: ../src/gtimelog/main.py:1410
 msgid "{0:%A, %Y-%m-%d}\n"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1431
+#: ../src/gtimelog/main.py:1435
+#, python-brace-format
+msgid "Total for {0}: {1}"
+msgstr ""
+
+#: ../src/gtimelog/main.py:1470
 msgid "({0:%H:%M}-{1:%H:%M})"
 msgstr "({0:%H:%M}–{1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1497
+#: ../src/gtimelog/main.py:1536
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1498
+#: ../src/gtimelog/main.py:1537
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1500
+#: ../src/gtimelog/main.py:1539
 #, python-brace-format
 msgid "Total work done this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1501
+#: ../src/gtimelog/main.py:1540
 #, python-brace-format
 msgid "Total work done this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1503
+#: ../src/gtimelog/main.py:1542
 #, python-brace-format
 msgid "Total work done this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1504
+#: ../src/gtimelog/main.py:1543
 #, python-brace-format
 msgid "Total work done this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1523
+#: ../src/gtimelog/main.py:1562
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1524
+#: ../src/gtimelog/main.py:1563
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1526
+#: ../src/gtimelog/main.py:1565
 #, python-brace-format
 msgid "Total slacking this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1527
+#: ../src/gtimelog/main.py:1566
 #, python-brace-format
 msgid "Total slacking this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1529
+#: ../src/gtimelog/main.py:1568
 #, python-brace-format
 msgid "Total slacking this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1530
+#: ../src/gtimelog/main.py:1569
 #, python-brace-format
 msgid "Total slacking this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1554
+#: ../src/gtimelog/main.py:1593
 msgid "Time left at work: {0} (should've finished at {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1557
+#: ../src/gtimelog/main.py:1596
 msgid "Time left at work: {0} (till {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1571
+#: ../src/gtimelog/main.py:1610
 #, python-brace-format
 msgid "At office today: {0} ({1} overtime)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1577
+#: ../src/gtimelog/main.py:1616
 #, python-brace-format
 msgid "At office today: {0} ({1} left)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1739
+#: ../src/gtimelog/main.py:1777
 msgid "Tasks"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1754
+#: ../src/gtimelog/main.py:1792
 msgid "Other"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1776 ../src/gtimelog/menus.ui.h:1
+#: ../src/gtimelog/main.py:1814 ../src/gtimelog/menus.ui.h:1
 msgid "Preferences"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1780
+#: ../src/gtimelog/main.py:1818
 msgid "Close"
 msgstr ""
 
@@ -409,4 +414,8 @@ msgstr ""
 
 #: ../src/gtimelog/menus.ui.h:16
 msgid "Month"
+msgstr ""
+
+#: ../src/gtimelog/menus.ui.h:17
+msgid "Filter"
 msgstr ""

--- a/po/gtimelog.pot
+++ b/po/gtimelog.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-12 09:43+0200\n"
+"POT-Creation-Date: 2016-04-01 12:19+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: ../gtimelog.desktop.in.h:1 ../src/gtimelog/main.py:178
-#: ../src/gtimelog/main.py:1076 ../src/gtimelog/about.ui.h:1
+#: ../src/gtimelog/main.py:1095 ../src/gtimelog/about.ui.h:1
 #: ../src/gtimelog/gtimelog.ui.h:10
 msgid "Time Log"
 msgstr ""
@@ -89,164 +89,169 @@ msgstr ""
 msgid "Settings already migrated to GSettings (org.gtimelog)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:700
+#: ../src/gtimelog/main.py:713
 #, python-brace-format
 msgid "Settings from {filename} migrated to GSettings (org.gtimelog)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:748
+#: ../src/gtimelog/main.py:761
 msgid "Report already sent"
 msgstr ""
 
-#: ../src/gtimelog/main.py:752
+#: ../src/gtimelog/main.py:765
 msgid "Report already sent (to {})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:767
+#: ../src/gtimelog/main.py:780
 msgid "Downloading tasks..."
 msgstr ""
 
-#: ../src/gtimelog/main.py:782
+#: ../src/gtimelog/main.py:795
 msgid "Download failed."
 msgstr ""
 
-#: ../src/gtimelog/main.py:929
+#: ../src/gtimelog/main.py:942
 msgid "{0:%A, %Y-%m-%d} (week {1:0>2})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:935
+#: ../src/gtimelog/main.py:948
 msgid "{0}, week {1} ({2:%B %-d}-{3:%-d})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:938
+#: ../src/gtimelog/main.py:951
 msgid "{0:%B %Y}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1006
+#: ../src/gtimelog/main.py:1022
 msgid "Report"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1029
+#: ../src/gtimelog/main.py:1045
 msgid "Couldn't send email to {}."
 msgstr ""
 
-#: ../src/gtimelog/main.py:1050
+#: ../src/gtimelog/main.py:1066
 #, python-format
 msgid "Couldn't execute %s: %s"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1054
+#: ../src/gtimelog/main.py:1070
 #, python-format
 msgid "Couldn't send email: %s returned code %d"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1064
+#: ../src/gtimelog/main.py:1080
 msgid "Couldn't append to {}: {}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1143
+#: ../src/gtimelog/main.py:1162
 msgid "%H:%M"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1384
+#: ../src/gtimelog/main.py:1410
 msgid "{0:%A, %Y-%m-%d}\n"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1431
+#: ../src/gtimelog/main.py:1435
+#, python-brace-format
+msgid "Total for {0}: {1}"
+msgstr ""
+
+#: ../src/gtimelog/main.py:1470
 msgid "({0:%H:%M}-{1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1497
+#: ../src/gtimelog/main.py:1536
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1498
+#: ../src/gtimelog/main.py:1537
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1500
+#: ../src/gtimelog/main.py:1539
 #, python-brace-format
 msgid "Total work done this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1501
+#: ../src/gtimelog/main.py:1540
 #, python-brace-format
 msgid "Total work done this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1503
+#: ../src/gtimelog/main.py:1542
 #, python-brace-format
 msgid "Total work done this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1504
+#: ../src/gtimelog/main.py:1543
 #, python-brace-format
 msgid "Total work done this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1523
+#: ../src/gtimelog/main.py:1562
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1524
+#: ../src/gtimelog/main.py:1563
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1526
+#: ../src/gtimelog/main.py:1565
 #, python-brace-format
 msgid "Total slacking this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1527
+#: ../src/gtimelog/main.py:1566
 #, python-brace-format
 msgid "Total slacking this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1529
+#: ../src/gtimelog/main.py:1568
 #, python-brace-format
 msgid "Total slacking this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1530
+#: ../src/gtimelog/main.py:1569
 #, python-brace-format
 msgid "Total slacking this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1554
+#: ../src/gtimelog/main.py:1593
 msgid "Time left at work: {0} (should've finished at {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1557
+#: ../src/gtimelog/main.py:1596
 msgid "Time left at work: {0} (till {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1571
+#: ../src/gtimelog/main.py:1610
 #, python-brace-format
 msgid "At office today: {0} ({1} overtime)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1577
+#: ../src/gtimelog/main.py:1616
 #, python-brace-format
 msgid "At office today: {0} ({1} left)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1739
+#: ../src/gtimelog/main.py:1777
 msgid "Tasks"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1754
+#: ../src/gtimelog/main.py:1792
 msgid "Other"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1776 ../src/gtimelog/menus.ui.h:1
+#: ../src/gtimelog/main.py:1814 ../src/gtimelog/menus.ui.h:1
 msgid "Preferences"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1780
+#: ../src/gtimelog/main.py:1818
 msgid "Close"
 msgstr ""
 
@@ -408,4 +413,8 @@ msgstr ""
 
 #: ../src/gtimelog/menus.ui.h:16
 msgid "Month"
+msgstr ""
+
+#: ../src/gtimelog/menus.ui.h:17
+msgid "Filter"
 msgstr ""

--- a/po/gtimelog.pot
+++ b/po/gtimelog.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-01 12:19+0300\n"
+"POT-Creation-Date: 2016-04-06 17:07+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: ../gtimelog.desktop.in.h:1 ../src/gtimelog/main.py:178
-#: ../src/gtimelog/main.py:1095 ../src/gtimelog/about.ui.h:1
+#: ../src/gtimelog/main.py:1096 ../src/gtimelog/about.ui.h:1
 #: ../src/gtimelog/gtimelog.ui.h:10
 msgid "Time Log"
 msgstr ""
@@ -144,114 +144,119 @@ msgstr ""
 msgid "Couldn't append to {}: {}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1162
+#: ../src/gtimelog/main.py:1163
 msgid "%H:%M"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1410
+#: ../src/gtimelog/main.py:1411
 msgid "{0:%A, %Y-%m-%d}\n"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1435
+#: ../src/gtimelog/main.py:1444
+#, python-brace-format
+msgid "Total for {0}: {1} ({2} per day)"
+msgstr ""
+
+#: ../src/gtimelog/main.py:1446
 #, python-brace-format
 msgid "Total for {0}: {1}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1470
+#: ../src/gtimelog/main.py:1479
 msgid "({0:%H:%M}-{1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1536
+#: ../src/gtimelog/main.py:1545
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1537
+#: ../src/gtimelog/main.py:1546
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1539
+#: ../src/gtimelog/main.py:1548
 #, python-brace-format
 msgid "Total work done this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1540
+#: ../src/gtimelog/main.py:1549
 #, python-brace-format
 msgid "Total work done this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1542
+#: ../src/gtimelog/main.py:1551
 #, python-brace-format
 msgid "Total work done this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1543
+#: ../src/gtimelog/main.py:1552
 #, python-brace-format
 msgid "Total work done this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1562
+#: ../src/gtimelog/main.py:1571
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week, {2} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1563
+#: ../src/gtimelog/main.py:1572
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1565
+#: ../src/gtimelog/main.py:1574
 #, python-brace-format
 msgid "Total slacking this week: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1566
+#: ../src/gtimelog/main.py:1575
 #, python-brace-format
 msgid "Total slacking this week: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1568
+#: ../src/gtimelog/main.py:1577
 #, python-brace-format
 msgid "Total slacking this month: {0} ({1} per day)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1569
+#: ../src/gtimelog/main.py:1578
 #, python-brace-format
 msgid "Total slacking this month: {0}"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1593
+#: ../src/gtimelog/main.py:1602
 msgid "Time left at work: {0} (should've finished at {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1596
+#: ../src/gtimelog/main.py:1605
 msgid "Time left at work: {0} (till {1:%H:%M})"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1610
+#: ../src/gtimelog/main.py:1619
 #, python-brace-format
 msgid "At office today: {0} ({1} overtime)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1616
+#: ../src/gtimelog/main.py:1625
 #, python-brace-format
 msgid "At office today: {0} ({1} left)"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1777
+#: ../src/gtimelog/main.py:1786
 msgid "Tasks"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1792
+#: ../src/gtimelog/main.py:1801
 msgid "Other"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1814 ../src/gtimelog/menus.ui.h:1
+#: ../src/gtimelog/main.py:1823 ../src/gtimelog/menus.ui.h:1
 msgid "Preferences"
 msgstr ""
 
-#: ../src/gtimelog/main.py:1818
+#: ../src/gtimelog/main.py:1827
 msgid "Close"
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtimelog 0.10.dev0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-01 12:18+0300\n"
+"POT-Creation-Date: 2016-04-06 17:07+0300\n"
 "PO-Revision-Date: 2015-09-04 10:53+0300\n"
 "Last-Translator: Marius Gedminas <marius@gedmin.as>\n"
 "Language-Team: <marius@gedmin.as>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: ../gtimelog.desktop.in.h:1 ../src/gtimelog/main.py:178
-#: ../src/gtimelog/main.py:1095 ../src/gtimelog/about.ui.h:1
+#: ../src/gtimelog/main.py:1096 ../src/gtimelog/about.ui.h:1
 #: ../src/gtimelog/gtimelog.ui.h:10
 msgid "Time Log"
 msgstr "Laiko žurnalas"
@@ -150,114 +150,119 @@ msgstr "Nepavyko išsiųsti laiško: %s grąžino kodą %d"
 msgid "Couldn't append to {}: {}"
 msgstr "Nepavyko rašyti į {}: {}"
 
-#: ../src/gtimelog/main.py:1162
+#: ../src/gtimelog/main.py:1163
 msgid "%H:%M"
 msgstr "%H:%M"
 
-#: ../src/gtimelog/main.py:1410
+#: ../src/gtimelog/main.py:1411
 msgid "{0:%A, %Y-%m-%d}\n"
 msgstr "{0:%A, %Y-%m-%d}\n"
 
-#: ../src/gtimelog/main.py:1435
+#: ../src/gtimelog/main.py:1444
+#, python-brace-format
+msgid "Total for {0}: {1} ({2} per day)"
+msgstr "Iš viso {0}: {1} (po {2} per dieną)"
+
+#: ../src/gtimelog/main.py:1446
 #, python-brace-format
 msgid "Total for {0}: {1}"
 msgstr "Iš viso {0}: {1}"
 
-#: ../src/gtimelog/main.py:1470
+#: ../src/gtimelog/main.py:1479
 msgid "({0:%H:%M}-{1:%H:%M})"
 msgstr "({0:%H:%M}–{1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1536
+#: ../src/gtimelog/main.py:1545
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week, {2} per day)"
 msgstr "Iš viso dirbta: {0} (šią savaitę {1}, po {2} per dieną)"
 
-#: ../src/gtimelog/main.py:1537
+#: ../src/gtimelog/main.py:1546
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week)"
 msgstr "Iš viso dirbta: {0} (šią savaitę {1})"
 
-#: ../src/gtimelog/main.py:1539
+#: ../src/gtimelog/main.py:1548
 #, python-brace-format
 msgid "Total work done this week: {0} ({1} per day)"
 msgstr "Iš viso dirbta šią savaitę: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1540
+#: ../src/gtimelog/main.py:1549
 #, python-brace-format
 msgid "Total work done this week: {0}"
 msgstr "Iš viso dirbta šią savaitę: {0}"
 
-#: ../src/gtimelog/main.py:1542
+#: ../src/gtimelog/main.py:1551
 #, python-brace-format
 msgid "Total work done this month: {0} ({1} per day)"
 msgstr "Iš viso dirbta šį mėnesį: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1543
+#: ../src/gtimelog/main.py:1552
 #, python-brace-format
 msgid "Total work done this month: {0}"
 msgstr "Iš viso dirbta šį mėnesį: {0}"
 
-#: ../src/gtimelog/main.py:1562
+#: ../src/gtimelog/main.py:1571
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week, {2} per day)"
 msgstr "Iš viso nedirbta: {0} (šią savaitę {1}, po {2} per dieną)"
 
-#: ../src/gtimelog/main.py:1563
+#: ../src/gtimelog/main.py:1572
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week)"
 msgstr "Iš viso nedirbta: {0} (šią savaitę {1})"
 
-#: ../src/gtimelog/main.py:1565
+#: ../src/gtimelog/main.py:1574
 #, python-brace-format
 msgid "Total slacking this week: {0} ({1} per day)"
 msgstr "Iš viso nedirbta šią savaitę: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1566
+#: ../src/gtimelog/main.py:1575
 #, python-brace-format
 msgid "Total slacking this week: {0}"
 msgstr "Iš viso nedirbta šią savaitę: {0}"
 
-#: ../src/gtimelog/main.py:1568
+#: ../src/gtimelog/main.py:1577
 #, python-brace-format
 msgid "Total slacking this month: {0} ({1} per day)"
 msgstr "Iš viso nedirbta šį mėnesį: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1569
+#: ../src/gtimelog/main.py:1578
 #, python-brace-format
 msgid "Total slacking this month: {0}"
 msgstr "Iš viso nedirbta šį mėnesį: {0}"
 
-#: ../src/gtimelog/main.py:1593
+#: ../src/gtimelog/main.py:1602
 msgid "Time left at work: {0} (should've finished at {1:%H:%M})"
 msgstr "Liko dirbti: {0} (reikėjo baigti {1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1596
+#: ../src/gtimelog/main.py:1605
 msgid "Time left at work: {0} (till {1:%H:%M})"
 msgstr "Liko dirbti: {0} (iki {1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1610
+#: ../src/gtimelog/main.py:1619
 #, python-brace-format
 msgid "At office today: {0} ({1} overtime)"
 msgstr "Šiandien darbe: {0} ({1} per daug)"
 
-#: ../src/gtimelog/main.py:1616
+#: ../src/gtimelog/main.py:1625
 #, python-brace-format
 msgid "At office today: {0} ({1} left)"
 msgstr "Šiandien darbe: {0} (liko {1})"
 
-#: ../src/gtimelog/main.py:1777
+#: ../src/gtimelog/main.py:1786
 msgid "Tasks"
 msgstr "Užduotys"
 
-#: ../src/gtimelog/main.py:1792
+#: ../src/gtimelog/main.py:1801
 msgid "Other"
 msgstr "Kitos"
 
-#: ../src/gtimelog/main.py:1814 ../src/gtimelog/menus.ui.h:1
+#: ../src/gtimelog/main.py:1823 ../src/gtimelog/menus.ui.h:1
 msgid "Preferences"
 msgstr "Nustatymai"
 
-#: ../src/gtimelog/main.py:1818
+#: ../src/gtimelog/main.py:1827
 msgid "Close"
 msgstr "Uždaryti"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtimelog 0.10.dev0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-12 09:43+0200\n"
+"POT-Creation-Date: 2016-04-01 12:18+0300\n"
 "PO-Revision-Date: 2015-09-04 10:53+0300\n"
 "Last-Translator: Marius Gedminas <marius@gedmin.as>\n"
 "Language-Team: <marius@gedmin.as>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: ../gtimelog.desktop.in.h:1 ../src/gtimelog/main.py:178
-#: ../src/gtimelog/main.py:1076 ../src/gtimelog/about.ui.h:1
+#: ../src/gtimelog/main.py:1095 ../src/gtimelog/about.ui.h:1
 #: ../src/gtimelog/gtimelog.ui.h:10
 msgid "Time Log"
 msgstr "Laiko žurnalas"
@@ -95,164 +95,169 @@ msgstr ""
 msgid "Settings already migrated to GSettings (org.gtimelog)"
 msgstr "Nustatymai jau buvo perkelti į GSettings (org.gtimelog)"
 
-#: ../src/gtimelog/main.py:700
+#: ../src/gtimelog/main.py:713
 #, python-brace-format
 msgid "Settings from {filename} migrated to GSettings (org.gtimelog)"
 msgstr "Nustatymai perkelti iš {filename} į GSettings (org.gtimelog)"
 
-#: ../src/gtimelog/main.py:748
+#: ../src/gtimelog/main.py:761
 msgid "Report already sent"
 msgstr "Ataskaita jau buvo išsiųsta"
 
-#: ../src/gtimelog/main.py:752
+#: ../src/gtimelog/main.py:765
 msgid "Report already sent (to {})"
 msgstr "Ataskaita jau buvo išsiųsta kitam gavėjui ({})"
 
-#: ../src/gtimelog/main.py:767
+#: ../src/gtimelog/main.py:780
 msgid "Downloading tasks..."
 msgstr "Parsiunčiamos užduotys..."
 
-#: ../src/gtimelog/main.py:782
+#: ../src/gtimelog/main.py:795
 msgid "Download failed."
 msgstr "Nepavyko parsisiųsti užduočių."
 
-#: ../src/gtimelog/main.py:929
+#: ../src/gtimelog/main.py:942
 msgid "{0:%A, %Y-%m-%d} (week {1:0>2})"
 msgstr "{0:%A, %Y-%m-%d} ({1} savaitė)"
 
-#: ../src/gtimelog/main.py:935
+#: ../src/gtimelog/main.py:948
 msgid "{0}, week {1} ({2:%B %-d}-{3:%-d})"
 msgstr "{0}, {1} savaitė ({2:%B %-d}–{3:%-d})"
 
-#: ../src/gtimelog/main.py:938
+#: ../src/gtimelog/main.py:951
 msgid "{0:%B %Y}"
 msgstr "{0:%Y %B} mėn."
 
-#: ../src/gtimelog/main.py:1006
+#: ../src/gtimelog/main.py:1022
 msgid "Report"
 msgstr "Ataskaita"
 
-#: ../src/gtimelog/main.py:1029
+#: ../src/gtimelog/main.py:1045
 msgid "Couldn't send email to {}."
 msgstr "Nepavyko išsiųsti laiško {}."
 
-#: ../src/gtimelog/main.py:1050
+#: ../src/gtimelog/main.py:1066
 #, python-format
 msgid "Couldn't execute %s: %s"
 msgstr "Nepavyko paleisti %s: %s"
 
-#: ../src/gtimelog/main.py:1054
+#: ../src/gtimelog/main.py:1070
 #, python-format
 msgid "Couldn't send email: %s returned code %d"
 msgstr "Nepavyko išsiųsti laiško: %s grąžino kodą %d"
 
-#: ../src/gtimelog/main.py:1064
+#: ../src/gtimelog/main.py:1080
 msgid "Couldn't append to {}: {}"
 msgstr "Nepavyko rašyti į {}: {}"
 
-#: ../src/gtimelog/main.py:1143
+#: ../src/gtimelog/main.py:1162
 msgid "%H:%M"
 msgstr "%H:%M"
 
-#: ../src/gtimelog/main.py:1384
+#: ../src/gtimelog/main.py:1410
 msgid "{0:%A, %Y-%m-%d}\n"
 msgstr "{0:%A, %Y-%m-%d}\n"
 
-#: ../src/gtimelog/main.py:1431
+#: ../src/gtimelog/main.py:1435
+#, python-brace-format
+msgid "Total for {0}: {1}"
+msgstr "Iš viso {0}: {1}"
+
+#: ../src/gtimelog/main.py:1470
 msgid "({0:%H:%M}-{1:%H:%M})"
 msgstr "({0:%H:%M}–{1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1497
+#: ../src/gtimelog/main.py:1536
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week, {2} per day)"
 msgstr "Iš viso dirbta: {0} (šią savaitę {1}, po {2} per dieną)"
 
-#: ../src/gtimelog/main.py:1498
+#: ../src/gtimelog/main.py:1537
 #, python-brace-format
 msgid "Total work done: {0} ({1} this week)"
 msgstr "Iš viso dirbta: {0} (šią savaitę {1})"
 
-#: ../src/gtimelog/main.py:1500
+#: ../src/gtimelog/main.py:1539
 #, python-brace-format
 msgid "Total work done this week: {0} ({1} per day)"
 msgstr "Iš viso dirbta šią savaitę: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1501
+#: ../src/gtimelog/main.py:1540
 #, python-brace-format
 msgid "Total work done this week: {0}"
 msgstr "Iš viso dirbta šią savaitę: {0}"
 
-#: ../src/gtimelog/main.py:1503
+#: ../src/gtimelog/main.py:1542
 #, python-brace-format
 msgid "Total work done this month: {0} ({1} per day)"
 msgstr "Iš viso dirbta šį mėnesį: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1504
+#: ../src/gtimelog/main.py:1543
 #, python-brace-format
 msgid "Total work done this month: {0}"
 msgstr "Iš viso dirbta šį mėnesį: {0}"
 
-#: ../src/gtimelog/main.py:1523
+#: ../src/gtimelog/main.py:1562
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week, {2} per day)"
 msgstr "Iš viso nedirbta: {0} (šią savaitę {1}, po {2} per dieną)"
 
-#: ../src/gtimelog/main.py:1524
+#: ../src/gtimelog/main.py:1563
 #, python-brace-format
 msgid "Total slacking: {0} ({1} this week)"
 msgstr "Iš viso nedirbta: {0} (šią savaitę {1})"
 
-#: ../src/gtimelog/main.py:1526
+#: ../src/gtimelog/main.py:1565
 #, python-brace-format
 msgid "Total slacking this week: {0} ({1} per day)"
 msgstr "Iš viso nedirbta šią savaitę: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1527
+#: ../src/gtimelog/main.py:1566
 #, python-brace-format
 msgid "Total slacking this week: {0}"
 msgstr "Iš viso nedirbta šią savaitę: {0}"
 
-#: ../src/gtimelog/main.py:1529
+#: ../src/gtimelog/main.py:1568
 #, python-brace-format
 msgid "Total slacking this month: {0} ({1} per day)"
 msgstr "Iš viso nedirbta šį mėnesį: {0} (po {1} per dieną)"
 
-#: ../src/gtimelog/main.py:1530
+#: ../src/gtimelog/main.py:1569
 #, python-brace-format
 msgid "Total slacking this month: {0}"
 msgstr "Iš viso nedirbta šį mėnesį: {0}"
 
-#: ../src/gtimelog/main.py:1554
+#: ../src/gtimelog/main.py:1593
 msgid "Time left at work: {0} (should've finished at {1:%H:%M})"
 msgstr "Liko dirbti: {0} (reikėjo baigti {1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1557
+#: ../src/gtimelog/main.py:1596
 msgid "Time left at work: {0} (till {1:%H:%M})"
 msgstr "Liko dirbti: {0} (iki {1:%H:%M})"
 
-#: ../src/gtimelog/main.py:1571
+#: ../src/gtimelog/main.py:1610
 #, python-brace-format
 msgid "At office today: {0} ({1} overtime)"
 msgstr "Šiandien darbe: {0} ({1} per daug)"
 
-#: ../src/gtimelog/main.py:1577
+#: ../src/gtimelog/main.py:1616
 #, python-brace-format
 msgid "At office today: {0} ({1} left)"
 msgstr "Šiandien darbe: {0} (liko {1})"
 
-#: ../src/gtimelog/main.py:1739
+#: ../src/gtimelog/main.py:1777
 msgid "Tasks"
 msgstr "Užduotys"
 
-#: ../src/gtimelog/main.py:1754
+#: ../src/gtimelog/main.py:1792
 msgid "Other"
 msgstr "Kitos"
 
-#: ../src/gtimelog/main.py:1776 ../src/gtimelog/menus.ui.h:1
+#: ../src/gtimelog/main.py:1814 ../src/gtimelog/menus.ui.h:1
 msgid "Preferences"
 msgstr "Nustatymai"
 
-#: ../src/gtimelog/main.py:1780
+#: ../src/gtimelog/main.py:1818
 msgid "Close"
 msgstr "Uždaryti"
 
@@ -415,6 +420,10 @@ msgstr "Savaitė"
 #: ../src/gtimelog/menus.ui.h:16
 msgid "Month"
 msgstr "Mėnuo"
+
+#: ../src/gtimelog/menus.ui.h:17
+msgid "Filter"
+msgstr "Filtruoti"
 
 #~ msgid "J. Random Hacker <jrh@example.com>"
 #~ msgstr "Vardenis Pavardenis <vp@example.com>"

--- a/src/gtimelog/gtimelog.ui
+++ b/src/gtimelog/gtimelog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.1 -->
+<!-- Generated with glade 3.19.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkImage" id="image1">
@@ -54,19 +54,52 @@
                 <property name="position">600</property>
                 <property name="position_set">True</property>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                  <object class="GtkBox" id="box1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkTextView" id="log_view">
+                      <object class="GtkSearchBar" id="search_bar">
+                        <property name="visible">True</property>
+                        <property name="app_paintable">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkSearchEntry" id="search_entry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="primary_icon_name">edit-find-symbolic</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="primary_icon_sensitive">False</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="pixels_above_lines">2</property>
-                        <property name="editable">False</property>
-                        <property name="wrap_mode">word</property>
-                        <property name="left_margin">6</property>
-                        <property name="right_margin">6</property>
+                        <child>
+                          <object class="GtkTextView" id="log_view">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="pixels_above_lines">2</property>
+                            <property name="editable">False</property>
+                            <property name="wrap_mode">word</property>
+                            <property name="left_margin">6</property>
+                            <property name="right_margin">6</property>
+                          </object>
+                        </child>
                       </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1433,9 +1433,17 @@ class LogView(Gtk.TextView):
             return # bug!
         if self.filter_text:
             self.w('\n')
-            self.wfmt(_('Total for {0}: {1}'),
-                      (self.filter_text, 'highlight'),
-                      (format_duration(total), 'duration'))
+            args = [
+                (self.filter_text, 'highlight'),
+                (format_duration(total), 'duration'),
+            ]
+            work_days = window.count_days()
+            if work_days > 1:
+                per_diem = total / work_days
+                args.append((format_duration(per_diem), 'duration'))
+                self.wfmt(_('Total for {0}: {1} ({2} per day)'), *args)
+            else:
+                self.wfmt(_('Total for {0}: {1}'), *args)
             self.w('\n')
         self.reposition_cursor()
         self.add_footer()

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1082,6 +1082,7 @@ class Window(Gtk.ApplicationWindow):
     def on_cancel_report(self, action=None, parameter=None):
         if self.main_stack.get_visible_child_name() != 'report':
             self.search_bar.set_search_mode(False)
+            self.filter_text = ''
             return
         self.main_stack.set_visible_child_name('entry')
         self.view_button.show()

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1450,7 +1450,8 @@ class LogView(Gtk.TextView):
         self.scroll_to_end()
 
     def entry_added(self, same_day):
-        if self.detail_level == 'chronological' and same_day:
+        if (self.detail_level == 'chronological' and same_day
+                and not self.filter_text):
             self.delete_footer()
             self.write_item(self.timelog.last_entry())
             self.add_footer()

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -252,6 +252,7 @@ class Application(Gtk.Application):
         self.set_accels_for_action("win.time-range::month", ["<Alt>6"])
         self.set_accels_for_action("win.show-task-pane", ["F9"])
         self.set_accels_for_action("win.show-menu", ["F10"])
+        self.set_accels_for_action("win.show-search-bar", ["<Primary>F"])
         self.set_accels_for_action("win.go-back", ["<Alt>Left"])
         self.set_accels_for_action("win.go-forward", ["<Alt>Right"])
         self.set_accels_for_action("win.go-home", ["<Alt>Home"])
@@ -463,6 +464,10 @@ class Window(Gtk.ApplicationWindow):
         type=str, default='day', nick='Time range',
         blurb='Time range to show (day/week/month)')
 
+    filter_text = GObject.Property(
+        type=str, default='', nick='Filter text',
+        blurb='Show only tasks matching this substring')
+
     class Actions(object):
 
         def __init__(self, win):
@@ -489,6 +494,9 @@ class Window(Gtk.ApplicationWindow):
 
             self.show_menu = PropertyAction.new("show-menu", win.menu_button, "active")
             win.add_action(self.show_menu)
+
+            self.show_search_bar = PropertyAction.new("show-search-bar", win.search_bar, "search-mode-enabled")
+            win.add_action(self.show_search_bar)
 
             for action_name in ['go-back', 'go-forward', 'go-home', 'add-entry', 'report', 'send-report', 'cancel-report']:
                 action = Gio.SimpleAction.new(action_name, None)
@@ -576,6 +584,11 @@ class Window(Gtk.ApplicationWindow):
         self.bind_property('time_range', self.log_view, 'time_range', GObject.BindingFlags.SYNC_CREATE)
         self.task_entry.bind_property('text', self.log_view, 'current_task', GObject.BindingFlags.DEFAULT)
         self.bind_property('subtitle', self.headerbar, 'subtitle', GObject.BindingFlags.DEFAULT)
+        self.bind_property('filter_text', self.log_view, 'filter_text', GObject.BindingFlags.DEFAULT)
+
+        self.search_bar = builder.get_object("search_bar")
+        self.search_entry = builder.get_object("search_entry")
+        self.search_entry.connect('search-changed', self.on_search_changed)
 
         self.task_pane = builder.get_object("task_pane")
         self.task_list = TaskListView()
@@ -945,6 +958,9 @@ class Window(Gtk.ApplicationWindow):
         assert self.time_range in {'day', 'week', 'month'}
         self.notify('subtitle')
 
+    def on_search_changed(self, *args):
+        self.filter_text = self.search_entry.get_text()
+
     def on_go_back(self, action, parameter):
         if self.time_range == 'day':
             self.date -= datetime.timedelta(1)
@@ -1064,6 +1080,9 @@ class Window(Gtk.ApplicationWindow):
             log.error(_("Couldn't append to {}: {}").format(record.filename, e))
 
     def on_cancel_report(self, action=None, parameter=None):
+        if self.main_stack.get_visible_child_name() != 'report':
+            self.search_bar.set_search_mode(False)
+            return
         self.main_stack.set_visible_child_name('entry')
         self.view_button.show()
         self.task_pane_button.show()
@@ -1295,6 +1314,10 @@ class LogView(Gtk.TextView):
         type=object, default=None, nick='Now',
         blurb='Current date and time')
 
+    filter_text = GObject.Property(
+        type=str, default='', nick='Filter text',
+        blurb='Show only tasks matching this substring')
+
     def __init__(self):
         Gtk.TextView.__init__(self)
         self._extended_footer = False
@@ -1312,6 +1335,7 @@ class LogView(Gtk.TextView):
         self.connect('notify::office-hours', self.queue_footer_update)
         self.connect('notify::current-task', self.queue_footer_update)
         self.connect('notify::now', self.queue_footer_update)
+        self.connect('notify::filter-text', self.queue_update)
 
     def queue_update(self, *args):
         if not self._update_pending:
@@ -1336,6 +1360,7 @@ class LogView(Gtk.TextView):
         buffer.create_tag('today', foreground='#204a87')     # Tango dark blue
         buffer.create_tag('duration', foreground='#ce5c00')  # Tango dark orange
         buffer.create_tag('time', foreground='#4e9a06')      # Tango dark green
+        buffer.create_tag('highlight', foreground='#4e9a06') # Tango dark green
         buffer.create_tag('slacking', foreground='gray')
 
     def get_time_window(self):
@@ -1374,6 +1399,7 @@ class LogView(Gtk.TextView):
         if self.timelog is None:
             return # not loaded yet
         window = self.get_time_window()
+        total = datetime.timedelta(0)
         if self.detail_level == 'chronological':
             prev = None
             for item in window.all_entries():
@@ -1382,21 +1408,34 @@ class LogView(Gtk.TextView):
                     self.w("\n")
                 if self.time_range != 'day' and first_of_day:
                     self.w(_("{0:%A, %Y-%m-%d}\n").format(item.start))
-                self.write_item(item)
+                if self.filter_text in item.entry:
+                    self.write_item(item)
+                    total += item.duration
                 prev = item.start
         elif self.detail_level == 'grouped':
             work, slack = window.grouped_entries()
             for start, entry, duration in work + slack:
-                self.write_group(entry, duration)
+                if self.filter_text in entry:
+                    self.write_group(entry, duration)
+                    total += duration
         elif self.detail_level == 'summary':
             entries, totals = window.categorized_work_entries()
             no_cat = totals.pop(None, None)
+            categories = sorted(totals.items())
             if no_cat is not None:
-                self.write_group('no category', no_cat)
-            for category, duration in sorted(totals.items()):
-                self.write_group(category, duration)
+                categories = [('no category', no_cat)] + categories
+            for category, duration in categories:
+                if self.filter_text in category:
+                    self.write_group(category, duration)
+                    total += duration
         else:
             return # bug!
+        if self.filter_text:
+            self.w('\n')
+            self.wfmt(_('Total for {0}: {1}'),
+                      (self.filter_text, 'highlight'),
+                      (format_duration(total), 'duration'))
+            self.w('\n')
         self.reposition_cursor()
         self.add_footer()
         self.scroll_to_end()

--- a/src/gtimelog/menus.ui
+++ b/src/gtimelog/menus.ui
@@ -81,5 +81,11 @@
         <attribute name="target">month</attribute>
       </item>
     </section>
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Filter</attribute>
+        <attribute name="action">win.show-search-bar</attribute>
+      </item>
+    </section>
   </menu>
 </interface>


### PR DESCRIPTION
Press Ctrl+F to open it (or click the new View menu entry).  Type some text.  Only those tasks matching the text will be shown in the task log, along with the total time taken by those tasks.

This performs a simple substring filtering.  It is sufficient for me right now.

You can cancel the filtering by pressing Esc or Ctrl+F again.

Incidentally, this also fixes #86.

![ekrano nuotrauka is 2016-04-01 12-20-44](https://cloud.githubusercontent.com/assets/159967/14203034/36ebb6d4-f804-11e5-93ed-c3764b62173e.png)
