### PR TITLE
Make symlink to gtimelog in source directory work

### DIFF
--- a/gtimelog
+++ b/gtimelog
@@ -5,7 +5,8 @@ Script to run GTimeLog from the source checkout without installing
 import os
 import sys
 
-pkgdir = os.path.join(os.path.dirname(__file__), 'src')
+basedir = os.path.dirname(os.path.realpath(__file__))
+pkgdir = os.path.join(basedir, 'src')
 sys.path.insert(0, pkgdir)
 
 from gtimelog.main import main


### PR DESCRIPTION
I did
```
  ln -s $PWD/gtimelog ~/bin/
```
but the sources could not be found.