### PR TITLE
Add flatpak manifest

### DIFF
--- a/flatpak/desktop-file-install-fix.patch
+++ b/flatpak/desktop-file-install-fix.patch
@@ -1,0 +1,12 @@
+*** old/setup.py
+--- new/setup.py
+***************
+*** 87,90 ****
+--- 87,93 ----
+      gtimelog = gtimelog.main:main
+      """,
+      install_requires=['PyGObject'],
++     data_files = [
++         ('/app/share/applications', ['gtimelog.desktop']),
++     ],
+  )

--- a/flatpak/org.gtimelog.GTimeLog.json
+++ b/flatpak/org.gtimelog.GTimeLog.json
@@ -1,0 +1,35 @@
+{
+    "id": "org.gtimelog.GTimeLog",
+    "runtime": "org.gnome.Platform",
+    "sdk": "org.gnome.Sdk",
+    "command": "gtimelog",
+    "tags": ["nightly"],
+    "modules": [
+        {
+            "name": "gtimelog",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/gtimelog/gtimelog.git"
+                },
+                {
+                    "type": "patch",
+                    "path": "desktop-file-install-fix.patch"
+                }
+            ],
+            "no-make-install": true,
+            "buildsystem": "simple",
+            "build-commands": ["python3 setup.py install --prefix=/app "]
+        }
+    ],
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+        /* Wayland access */
+        "--socket=wayland",
+        "--socket=session-bus"
+    ],
+    "rename-desktop-file": "gtimelog.desktop",
+    "rename-appdata-file": "gtimelog.appdata.xml",
+    "desktop-file-name-prefix": "(Nightly) "
+}


### PR DESCRIPTION
This PR contains the manifest file required to build [GTimeLog](https://gtimelog.org/) as a [Flatpak](https://flatpak.org/).

## Build
1. Make sure flatpak is installed in your system.
2. Clone the repository.
3. Run `flatpak-builder --user --install gflatlog gtimelog/flatpak/org.gtimelog.GTimeLog.json`.

This command will build the flatpak according to the manifest file `gtimelog/flatpak/org.gtimelog.GTimeLog.json` using `gflatlog` as the build directory. Then it will install it as the user.

(For information on alternative ways to build (e.g. to a local repo), please refer to the Flatpak [documentation](http://docs.flatpak.org/en/latest/))

## Issues
For both of these issues, someone who has Distutils experience may be helpful.

### App icon does not work
I tried installing the app icon the way the desktop file is installed but I could not make Flatpak see it. 

### Setup file references /app directly
In setup.py, /app is referenced directly for data_files. I thought setup would install relative to the installation prefix when it is left out but I could not get Flatpak to see the desktop file with a relative path. 

This issue prevents the patch from being upstreamed.