### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
     - pip install coverage coveralls
     - pip install freezegun mock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
     - 3.4
     - 3.5
     - 3.6
+matrix:
+  include:
     - python: 3.7
       dist: xenial
       sudo: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changelog
   a trailing space after the ':' were considered to be uncategorized
   (GH: #117).
 
+* Add Python 3.7 support.
+
 * Drop Python 3.3 support.
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
 
 init:
   - "echo %PYTHON%"

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Office/Business',
     ],
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36
+    py27,py34,py35,py36,py37
 
 [testenv]
 setenv =


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/9815 for the reason for the `sudo` and `dist: xenial` bits