### PR TITLE
Use os.startfile() for "Edit log" and "Edit tasks" on MS-Windows

### DIFF
--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -423,11 +423,17 @@ class Application(Gtk.Application):
     def on_quit(self, action, parameter):
         self.quit()
 
+    def open_in_editor(self, filename):
+        self.create_if_missing(filename)
+        if os.name == 'nt':
+            os.startfile(filename)
+        else:
+            uri = GLib.filename_to_uri(filename, None)
+            Gtk.show_uri(None, uri, Gdk.CURRENT_TIME)
+
     def on_edit_log(self, action, parameter):
         filename = Settings().get_timelog_file()
-        uri = GLib.filename_to_uri(filename, None)
-        self.create_if_missing(filename)
-        Gtk.show_uri(None, uri, Gdk.CURRENT_TIME)
+        self.open_in_editor(filename)
 
     def on_edit_tasks(self, action, parameter):
         gsettings = Gio.Settings.new("org.gtimelog")
@@ -435,11 +441,10 @@ class Application(Gtk.Application):
             uri = gsettings.get_string('task-list-edit-url')
             if self.get_active_window() is not None:
                 self.get_active_window().editing_remote_tasks = True
+            Gtk.show_uri(None, uri, Gdk.CURRENT_TIME)
         else:
             filename = Settings().get_task_list_file()
-            self.create_if_missing(filename)
-            uri = GLib.filename_to_uri(filename, None)
-        Gtk.show_uri(None, uri, Gdk.CURRENT_TIME)
+            self.open_in_editor(filename)
 
     def on_refresh_tasks(self, action, parameter):
         gsettings = Gio.Settings.new("org.gtimelog")


### PR DESCRIPTION
I'm using GTimeLog on MS-Windows and noticed that the menu entries "Edit log" and "Edit tasks" didn't work out of the box. As it turned out the `Gtk.show_uri()` didn't work to open the text editor. So i changed `Gtk.show_uri()` to `os.startfile()`. With this workaround (but only stepping in if running on MS-Windows) the mentioned menu entries work as expected.
Maybe this is also helpful for other MS-Windows users. Please feel free to decide if you find it worth to incorporate into upstream.