### PR TITLE
Exclude entries with three asterisks from totals

### DIFF
--- a/src/gtimelog/CONTRIBUTORS.rst
+++ b/src/gtimelog/CONTRIBUTORS.rst
@@ -34,6 +34,7 @@ In alphabetic order:
 - Rohan Mitchell
 - Shirish Agarwal  शिरीष अग्रवाल
 - Thom May
+- Till Hofmann
 - Tomaz Canabrava
 - Živilė Gedminaitė
 

--- a/src/gtimelog/tests/test_timelog.py
+++ b/src/gtimelog/tests/test_timelog.py
@@ -1251,8 +1251,9 @@ class TestTotals(unittest.TestCase):
         """
         2018-12-09 08:30: start at home
         2018-12-09 08:40: emails
-        2018-12-09 08:45: coffee **
-        2018-12-09 11:45: coding
+        2018-12-09 09:10: travel to work ***
+        2018-12-09 09:15: coffee **
+        2018-12-09 12:15: coding
         """)
 
     def setUp(self):

--- a/src/gtimelog/tests/test_timelog.py
+++ b/src/gtimelog/tests/test_timelog.py
@@ -1245,6 +1245,30 @@ class TestTimeLog(Mixins, unittest.TestCase):
                          ("-200 did stuff", None))
 
 
+class TestTotals(unittest.TestCase):
+
+    TEST_TIMELOG = textwrap.dedent(
+        """
+        2018-12-09 08:30: start at home
+        2018-12-09 08:40: emails
+        2018-12-09 08:45: coffee **
+        2018-12-09 11:45: coding
+        """)
+
+    def setUp(self):
+        self.tw = make_time_window(
+            StringIO(self.TEST_TIMELOG),
+            datetime.datetime(2018, 12, 9, 8, 0),
+            datetime.datetime(2018, 12, 9, 23, 59),
+            datetime.time(2, 0),
+        )
+
+    def test_TimeWindow_totals(self):
+        work, slack = self.tw.totals()
+        self.assertEqual(work, datetime.timedelta(hours=3, minutes=10))
+        self.assertEqual(slack, datetime.timedelta(hours=0, minutes=5))
+
+
 class TestFiltering(unittest.TestCase):
 
     TEST_TIMELOG = textwrap.dedent("""

--- a/src/gtimelog/timelog.py
+++ b/src/gtimelog/timelog.py
@@ -359,7 +359,9 @@ class TimeCollection(object):
                 continue
             if filter_text is not None and filter_text not in entry:
                 continue
-            if '**' in entry:
+            if '***' in entry:
+                continue
+            elif '**' in entry:
                 total_slacking += duration
             else:
                 total_work += duration


### PR DESCRIPTION
Entries with '***' should be completely ignored. Do not include them when computing the total.

Also add a simpler test case for totals that includes an entry with '***'. While the totals are already tested by the other test cases, this allows to see if there is a bug in the totals itself.

This fixes #132.