### PR TITLE
Fix error when using remote task list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,10 @@ Changelog
 
 - gnome-keyring is now a mandatory dependency.
 
-- GTK 3.18 or newer is now required.
+- GTK 3.18 or newer is now required (GH: #131).
+
+- Fixed an AttributeError in the undocmented remote task list feature
+  (GH: #153).
 
 
 0.11.3 (2019-04-23)

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -922,8 +922,8 @@ class Window(Gtk.ApplicationWindow):
             self.tasks_infobar.show()
         else:
             log.debug("Successfully downloaded tasks:\n  %s",
-                      content.decode('UTF-8', 'replace').replace('\n', '\n  '))
-            with open(cache_filename, 'wb') as f:
+                      content.replace('\n', '\n  '))
+            with open(cache_filename, 'w') as f:
                 f.write(content)
             self.check_reload_tasks()
             self.tasks_infobar.hide()


### PR DESCRIPTION
The error was

    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/gtimelog/main.py", line 979, in tasks_downloaded
        content.decode('UTF-8', 'replace').replace('\n', '\n  '))
    AttributeError: 'str' object has no attribute 'decode'

because apparently Soap gives us a unicode string (on Python 3) instead
of bytes?

I've tested the new code on both Python 2 and 3, on a URL that responds
with Content-Type: text/plain; charset=utf-8 and returns non-ASCII data.

Fixes #153.