### PR TITLE
Update website.rst: Packages no longer out of date

### DIFF
--- a/docs/website.rst
+++ b/docs/website.rst
@@ -27,7 +27,7 @@ You can get GTimeLog from the `Python Package Index`_::
 
     pip install gtimelog
 
-Packages exist in Debian_ and in Ubuntu_, but they're outdated at the moment.
+Packages exist in Debian_ and in Ubuntu_.
 
 .. _Python Package Index: https://pypi.python.org/pypi/gtimelog
 .. _debian: https://packages.debian.org/gtimelog


### PR DESCRIPTION
The stable/LTS (recommended) distributions of [Debian](https://packages.debian.org/buster/gtimelog) and [Ubuntu](https://packages.ubuntu.com/bionic/gtimelog) contain gtimelog 0.11, which [according to the releases page](https://github.com/gtimelog/gtimelog/releases) of this repository is the most recent release.

As the popularity of a piece software among GNU/Linux users often depends on whether or not said software is included (and up-to-date) in their distribution's repository, I propose to update the gtimelog website to reflect this fact.