### PR TITLE
[FIX] Attribute error if `timelog` or `tasks` member have not yet bee…

### DIFF
--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1342,12 +1342,12 @@ class Window(Gtk.ApplicationWindow):
             GLib.timeout_add_seconds(1, self.check_reload_tasks)
 
     def check_reload(self):
-        if self.timelog.check_reload():
+        if self.timelog and self.timelog.check_reload():
             self.notify('timelog')
             self.tick(True)
 
     def check_reload_tasks(self):
-        if self.tasks.check_reload():
+        if self.tasks and self.tasks.check_reload():
             self.notify('tasks')
 
     def enable_add_entry(self):


### PR DESCRIPTION
[FIX]

AttributeError: 'NoneType' object has no attribute 'check_reload'