### PR TITLE
209 positive time offset entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Changelog
 
 - Drop Python 2.7 and 3.5 support.
 
+- Add support for positive time offset syntax in entries.
+
 
 0.11.3 (2019-04-23)
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,8 +73,10 @@ Back-dating Entries
 
 If you forget to enter an activity, you can enter it after the fact by
 prefixing it with a full time ("09:30 morning meeting") or a two digit minute-offset
-("-10 morning meeting").  Note that the new activity must still be after
-the last entered event, or things will become confusing!
+("-10 morning meeting" or "+10 morning meeting"). Where "-" offsets from the
+the current time and "+" offsets from the last entry.
+Note that the new activity must still be after the last entered event and before the
+current time, or things will become confusing!
 
 
 Tasks pane

--- a/src/gtimelog/CONTRIBUTORS.rst
+++ b/src/gtimelog/CONTRIBUTORS.rst
@@ -22,6 +22,7 @@ In alphabetic order:
 - Jean Jordaan
 - Jeroen Langeveld
 - Jonatan Cloutier
+- Jonathan Snyder
 - Kees Cook
 - Lars Wirzenius
 - Laurynas Speičys

--- a/src/gtimelog/tests/test_timelog.py
+++ b/src/gtimelog/tests/test_timelog.py
@@ -1222,23 +1222,50 @@ class TestTimeLog(Mixins, unittest.TestCase):
                          ("15:20 did stuff", None))
 
     @freezegun.freeze_time("2015-05-12 16:27")
-    def test_parse_correction_recognizes_relative_times(self):
+    def test_parse_correction_recognizes_negative_relative_times(self):
         timelog = TimeLog(StringIO(), datetime.time(2, 0))
         self.assertEqual(timelog.parse_correction("-20 did stuff"),
                          ("did stuff", datetime.datetime(2015, 5, 12, 16, 7)))
 
     @freezegun.freeze_time("2015-05-12 16:27")
-    def test_parse_correction_ignores_relative_times_before_last_entry(self):
+    def test_parse_correction_recognizes_positive_relative_times(self):
+        timelog = TimeLog(StringIO("2015-05-12 15:50: stuff"),
+                          datetime.time(2, 0))
+        self.assertEqual(timelog.parse_correction("+20 did stuff"),
+                         ("did stuff", datetime.datetime(2015, 5, 12, 16, 10)))
+
+    @freezegun.freeze_time("2015-05-12 16:27")
+    def test_parse_correction_ignores_positive_relative_times_without_initial_entry(self):
+        timelog = TimeLog(StringIO(), datetime.time(2, 0))
+        self.assertEqual(timelog.parse_correction("+20 did stuff"),
+                         ("+20 did stuff", None))
+
+    @freezegun.freeze_time("2015-05-12 16:27")
+    def test_parse_correction_ignores_negative_relative_times_before_last_entry(self):
         timelog = TimeLog(StringIO("2015-05-12 16:00: stuff"),
                           datetime.time(2, 0))
         self.assertEqual(timelog.parse_correction("-30 did stuff"),
                          ("-30 did stuff", None))
 
     @freezegun.freeze_time("2015-05-12 16:27")
-    def test_parse_correction_ignores_bad_relative_times(self):
+    def test_parse_correction_ignores_positive_relative_times_in_the_future(self):
+        timelog = TimeLog(StringIO("2015-05-12 15:50: stuff"),
+                          datetime.time(2, 0))
+        self.assertEqual(timelog.parse_correction("+40 did stuff"),
+                         ("+40 did stuff", None))
+
+    @freezegun.freeze_time("2015-05-12 16:27")
+    def test_parse_correction_ignores_bad_negative_relative_times(self):
         timelog = TimeLog(StringIO(), datetime.time(2, 0))
         self.assertEqual(timelog.parse_correction("-200 did stuff"),
                          ("-200 did stuff", None))
+
+    @freezegun.freeze_time("2015-05-12 16:27")
+    def test_parse_correction_ignores_bad_positive_relative_times(self):
+        timelog = TimeLog(StringIO("2015-05-12 15:50: stuff"),
+                          datetime.time(2, 0))
+        self.assertEqual(timelog.parse_correction("+200 did stuff"),
+                         ("+200 did stuff", None))
 
 
 class TestTotals(unittest.TestCase):


### PR DESCRIPTION
Adds ability to add a positive time offset which is relative to the last created entry.

e.g.  `+30 meeting` will add a meeting entry 30 minutes after the last entry, provided the entry would not be in the future.

closes #209 