### PR TITLE
Change entry search to be fuzzy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Changelog
 
 - Focus the task entry on Ctrl+L (GH: #213).
 
+- Change entry search to be fuzzy. It is now only required to enter characters
+  of the entry in the correct order to find an entry.
+
 
 0.11.3 (2019-04-23)
 ~~~~~~~~~~~~~~~~~~~

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1215,8 +1215,21 @@ class TaskEntry(Gtk.Entry):
         self.completion_choices_as_set = set()
         completion.set_model(self.completion_choices)
         completion.set_text_column(0)
+        completion.set_match_func(
+            self.completion_match_func, self.completion_choices)
         if self.gtk_completion_enabled:
             self.set_completion(completion)
+
+    def completion_match_func(self, completion, search_text, tree_iter, data):
+        entry = data.get_value(tree_iter, 0).lower()
+        pos = 0
+        for char in search_text:
+            new_pos = entry.find(char, pos)
+            if new_pos == -1:
+                return False
+            else:
+                pos = new_pos
+        return True
 
     def gtk_completion_enabled_changed(self, *args):
         if self.gtk_completion_enabled:


### PR DESCRIPTION
It is now only required to enter characters of the entry in the correct order to find an entry.

Using the entries in the screenshot in the README.
'tr' would suggest the entry 'gtimelog: experimental rewrite (GH #31)' because the 't' on index 1 is followed by an 'r' later in the entry text.