### PR TITLE
Keep config file order in tasks pane

### DIFF
--- a/src/gtimelog/tests/test_timelog.py
+++ b/src/gtimelog/tests/test_timelog.py
@@ -1042,9 +1042,9 @@ class TestTaskList(Mixins, unittest.TestCase):
         '''))
         tasklist = TaskList(taskfile)
         self.assertEqual(tasklist.groups, [
-            ('Other', ['some task', 'other task']),
-            ('misc', ['paperwork']),
             ('project', ['do it', 'fix bugs']),
+            ('misc', ['paperwork']),
+            ('Other', ['some task', 'other task']),
         ])
 
     def test_unicode(self):

--- a/src/gtimelog/timelog.py
+++ b/src/gtimelog/timelog.py
@@ -1123,7 +1123,9 @@ class TaskList(object):
         except IOError:
             pass # the file's not there, so what?
         # append the "other" tasks at the end
-        self.groups = list(groups.items()) + [(self.other_title, others)]
+        self.groups = list(groups.items())
+        if others:
+            self.groups.append((self.other_title, others))
 
     def reload(self):
         """Reload the task list."""

--- a/src/gtimelog/timelog.py
+++ b/src/gtimelog/timelog.py
@@ -1107,6 +1107,7 @@ class TaskList(object):
     def load(self):
         """Load task list from a file named self.filename."""
         groups = {}
+        others = []
         self.last_mtime = get_mtime(self.filename)
         try:
             with open(self.filename, encoding='utf-8') as f:
@@ -1114,14 +1115,15 @@ class TaskList(object):
                     line = line.strip()
                     if not line or line.startswith('#'):
                         continue
-                    if ':' in line:
+                    if ':' in line:  # tasks with group prefix
                         group, task = [s.strip() for s in line.split(':', 1)]
-                    else:
-                        group, task = self.other_title, line
-                    groups.setdefault(group, []).append(task)
+                        groups.setdefault(group, []).append(task)
+                    else:  # "other" tasks
+                        others.append(line.strip())
         except IOError:
             pass # the file's not there, so what?
-        self.groups = sorted(groups.items())
+        # append the "other" tasks at the end
+        self.groups = list(groups.items()) + [(self.other_title, others)]
 
     def reload(self):
         """Reload the task list."""


### PR DESCRIPTION
The tasks themselve were anyway not sorted, so better be consistent. Makes also sure that the "Other" group is always at the end. Closes #182