### PR TITLE
Move from Soup 2.4 to Soup 3.0.

### DIFF
--- a/other-requirements.txt
+++ b/other-requirements.txt
@@ -2,7 +2,7 @@
 python-gobject
 python-gi-cairo
 gir1.2-gtk-3.0
-gir1.2-soup-2.4
+gir1.2-soup-3.0
 gir1.2-secret-1
 
 # build dependencies

--- a/src/gtimelog/secrets.py
+++ b/src/gtimelog/secrets.py
@@ -9,9 +9,8 @@ from .utils import require_version
 
 
 require_version('Gtk', '3.0')
-require_version('Soup', '2.4')
 require_version('Secret', '1')
-from gi.repository import Gio, GObject, Gtk, Secret, Soup
+from gi.repository import Gio, GObject, Gtk, Secret
 
 
 log = logging.getLogger('gtimelog.secrets')
@@ -53,12 +52,11 @@ def set_smtp_password(server, username, password):
 
 
 class Authenticator(object):
-    def __init__(self, soup_session: Soup.SessionAsync):
+    def __init__(self):
         self.pending = []
         self.lookup_in_progress = False
         self.username = None
         self.password = None
-        soup_session.connect('authenticate', self.http_auth_cb)
 
     def find_in_keyring(self, uri, callback):
         """


### PR DESCRIPTION
Using https://libsoup.org/libsoup-3.0/migrating-from-libsoup-2.html as a guide, I rewrote existing code base to Soup 3.0.

Test results:
```
% ./runtests
.........................................................................................................
----------------------------------------------------------------------
Ran 105 tests in 0.317s

OK
```

I also did manual testing with

```
gsettings set org.gtimelog remote-task-list true
gsettings set org.gtimelog task-list-url https://gist.github.com/mgedmin/4609f92e2c11502386f5/raw
```

As well as with an invalid URL.