### PR TITLE
Fix incomplete move to Soup 3.0 for authenticator (secrets.py).

### DIFF
--- a/src/gtimelog/secrets.py
+++ b/src/gtimelog/secrets.py
@@ -212,6 +212,8 @@ class Authenticator(object):
     def http_auth_finish(self, message, auth, username, password):
         if username and password:
             auth.authenticate(username, password)
+        else:
+            auth.cancel()
 
         self.lookup_in_progress = False
         self.maybe_pop_queue()


### PR DESCRIPTION
#238 was incomplete, as it didn't update secrets.py accordingly to the new Soup library version 3.0.

Now, I set

```
gsettings set org.gtimelog task-list-url http://httpbin.org/basic-auth/q/p
```

The user is q and the password is p.

Tested thus, always deleting the ~/.local/share/gtimelog/remote-tasks.txt in between:

*Cancelled authentication.
*Correct user/password, without saving in the keyring.
*Correct user/password, with saving in the keyring, deleting cache file and restarting gtimelog.
*Wrong user/password.

I couldn't contrast this with the existing behavior in 0.11.3-2 because there I get [this error](https://github.com/gtimelog/gtimelog/files/12585244/0.11.3-2.txt) (should I open an issue about it)?
