### PR TITLE
Use CSS Provider to set font-family

### DIFF
--- a/src/gtimelog/gtimelog.css
+++ b/src/gtimelog/gtimelog.css
@@ -1,1 +1,5 @@
-/* We don't have any custom CSS today! */
+/* GTK+ themes other than Adwaita ignore the 'monospace' property and
+   use a proportional font for text widgets. */
+.monospace {
+	font-family: monospace;
+}

--- a/src/gtimelog/gtimelog.ui
+++ b/src/gtimelog/gtimelog.ui
@@ -500,6 +500,9 @@
                     <property name="accepts_tab">False</property>
                     <property name="left_margin">6</property>
                     <property name="right_margin">6</property>
+		    <style>
+		      <class name="monospace"/>
+                  </style>
                   </object>
                 </child>
               </object>

--- a/src/gtimelog/main.py
+++ b/src/gtimelog/main.py
@@ -1786,9 +1786,6 @@ class ReportView(Gtk.TextView):
         self.connect('notify::recipient', self.update_already_sent_indication)
         self.bind_property('body', self.get_buffer(), 'text',
                            GObject.BindingFlags.BIDIRECTIONAL)
-        # GTK+ themes other than Adwaita ignore the 'monospace' property and
-        # use a proportional font for text widgets.
-        self.override_font(Pango.FontDescription.from_string("Monospace"))
 
         filename = Settings().get_report_log_file()
         self.record = ReportRecord(filename)


### PR DESCRIPTION
override_font is deprecated (since Gtk 3.16).

Fixes:
```
/home/juergen/ghq/github.com/gtimelog/gtimelog/src/gtimelog/main.py:1791: DeprecationWarning: Gtk.Widget.override_font is deprecated
  self.override_font(Pango.FontDescription.from_string("Monospace"))
```